### PR TITLE
i18nを用いたサンプルアプリの多言語化

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -11,8 +11,7 @@ class BooksController < ApplicationController
 
   # GET /books/1
   # GET /books/1.json
-  def show
-  end
+  def show; end
 
   # GET /books/new
   def new
@@ -20,8 +19,7 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /books
   # POST /books.json

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -15,7 +15,10 @@ class BooksController < ApplicationController
 
   # GET /books/1
   # GET /books/1.json
-  def show; end
+  def show
+    @edit = t('books.link.edit')
+    @back = t('books.link.back')
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -27,7 +27,10 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1/edit
-  def edit; end
+  def edit
+    @show = t('books.link.show')
+    @back = t('books.link.back')
+  end
 
   # POST /books
   # POST /books.json

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -23,6 +23,7 @@ class BooksController < ApplicationController
   # GET /books/new
   def new
     @book = Book.new
+    @back = t('books.link.back')
   end
 
   # GET /books/1/edit

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,6 +7,10 @@ class BooksController < ApplicationController
   # GET /books.json
   def index
     @books = Book.all
+    @show = t('books.link.show')
+    @edit = t('books.link.edit')
+    @destroy = t('books.link.destroy')
+    @create = t('books.link.create')
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,29 +7,20 @@ class BooksController < ApplicationController
   # GET /books.json
   def index
     @books = Book.all
-    @show = t('books.link.show')
-    @edit = t('books.link.edit')
-    @destroy = t('books.link.destroy')
-    @create = t('books.link.create')
   end
 
   # GET /books/1
   # GET /books/1.json
   def show
-    @edit = t('books.link.edit')
-    @back = t('books.link.back')
   end
 
   # GET /books/new
   def new
     @book = Book.new
-    @back = t('books.link.back')
   end
 
   # GET /books/1/edit
   def edit
-    @show = t('books.link.show')
-    @back = t('books.link.back')
   end
 
   # POST /books

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,6 @@
-<h1><%= t('books.edit.title') %></h1>
+<h1><%= t('title.edit') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to t('books.link.show'), @book %> |
-<%= link_to t('books.link.back'), books_path %>
+<%= link_to t('link.show'), @book %> |
+<%= link_to t('link.back'), books_path %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to @show, @book %> |
-<%= link_to @back, books_path %>
+<%= link_to t('books.link.show'), @book %> |
+<%= link_to t('books.link.back'), books_path %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Book</h1>
+<h1><%= t('books.edit.title') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Show', @book %> |
-<%= link_to 'Back', books_path %>
+<%= link_to @show, @book %> |
+<%= link_to @back, books_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t('books.index.title') %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Memo</th>
-      <th>Author</th>
-      <th>Picture</th>
+      <th><%= t('books.table.title') %></th>
+      <th><%= t('books.table.memo') %></th>
+      <th><%= t('books.table.author') %></th>
+      <th><%= t('books.table.picture') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to 'Show', book %></td>
-        <td><%= link_to 'Edit', edit_book_path(book) %></td>
-        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to @show, book %></td><!-- -->
+        <td><%= link_to @edit, edit_book_path(book) %></td><!-- -->
+        <td><%= link_to @destroy, book, method: :delete, data: { confirm: 'Are you sure?' } %></td><!-- -->
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Book', new_book_path %>
+<%= link_to @create, new_book_path %><!-- -->

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,10 +5,10 @@
 <table>
   <thead>
     <tr>
-      <th><%= t('books.table.title') %></th>
-      <th><%= t('books.table.memo') %></th>
-      <th><%= t('books.table.author') %></th>
-      <th><%= t('books.table.picture') %></th>
+      <th><%= book.title %></th>
+      <th><%= book.memo %></th>
+      <th><%= book.author %></th>
+      <th><%= book.picture %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= t('books.index.title') %></h1>
+<h1><%= t('title.index') %></h1>
 
 <table>
   <thead>
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to t('books.link.show'), book %></td>
-        <td><%= link_to t('books.link.edit'), edit_book_path(book) %></td>
-        <td><%= link_to t('books.link.destroy'), book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t('link.show'), book %></td>
+        <td><%= link_to t('link.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t('link.destroy'), book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to t('books.link.create'), new_book_path %>
+<%= link_to t('link.create'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to @show, book %></td><!-- -->
-        <td><%= link_to @edit, edit_book_path(book) %></td><!-- -->
-        <td><%= link_to @destroy, book, method: :delete, data: { confirm: 'Are you sure?' } %></td><!-- -->
+        <td><%= link_to @show, book %></td>
+        <td><%= link_to @edit, edit_book_path(book) %></td>
+        <td><%= link_to @destroy, book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to @create, new_book_path %><!-- -->
+<%= link_to @create, new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to @show, book %></td>
-        <td><%= link_to @edit, edit_book_path(book) %></td>
-        <td><%= link_to @destroy, book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t('books.link.show'), book %></td>
+        <td><%= link_to t('books.link.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t('books.link.destroy'), book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to @create, new_book_path %>
+<%= link_to t('books.link.create'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,10 +5,10 @@
 <table>
   <thead>
     <tr>
-      <th><%= book.title %></th>
-      <th><%= book.memo %></th>
-      <th><%= book.author %></th>
-      <th><%= book.picture %></th>
+      <th><%= Book.human_attribute_name("title") %></th>
+      <th><%= Book.human_attribute_name("memo") %></th>
+      <th><%= Book.human_attribute_name("author") %></th>
+      <th><%= Book.human_attribute_name("picture") %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Book</h1>
+<h1><%= t('books.new.title') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Back', books_path %>
+<%= link_to @back, books_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,5 @@
-<h1><%= t('books.new.title') %></h1>
+<h1><%= t('title.new') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to t('books.link.back'), books_path %>
+<%= link_to t('link.back'), books_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to @back, books_path %>
+<%= link_to t('books.link.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,5 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to t('books.link.edit'), edit_book_path(@book) %> |
-<%= link_to t('books.link.back'), books_path %>
+<%= link_to t('link.edit'), edit_book_path(@book) %> |
+<%= link_to t('link.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,5 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to @edit, edit_book_path(@book) %> |
-<%= link_to @back, books_path %>
+<%= link_to t('books.link.edit'), edit_book_path(@book) %> |
+<%= link_to t('books.link.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,24 +1,24 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= t('books.table.title') %></strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= t('books.table.memo') %></strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong>Author:</strong>
+  <strong><%= t('books.table.author') %></strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong>Picture:</strong>
+  <strong><%= t('books.table.picture') %></strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to 'Edit', edit_book_path(@book) %> |
-<%= link_to 'Back', books_path %>
+<%= link_to @edit, edit_book_path(@book) %> |
+<%= link_to @back, books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,22 +1,22 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong><%= t('books.table.title') %></strong>
+  <strong><%= book.title %></strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong><%= t('books.table.memo') %></strong>
+  <strong><%= book.memo %></strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong><%= t('books.table.author') %></strong>
+  <strong><%= book.author %></strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong><%= t('books.table.picture') %></strong>
+  <strong><%= book.author %></strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,22 +1,22 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong><%= book.title %></strong>
+  <strong><%= Book.human_attribute_name("title") %></strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong><%= book.memo %></strong>
+  <strong><%= Book.human_attribute_name("memo") %></strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong><%= book.author %></strong>
+  <strong><%= Book.human_attribute_name("author") %></strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong><%= book.author %></strong>
+  <strong><%= Book.human_attribute_name("picure") %></strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module BooksApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,24 +1,16 @@
 en:
-  books:
-    table:
-      title: Title
-      memo: Memo
-      author: Author
-      picture: Picture
-    link:
-      show: Show
-      edit: Edit
-      destroy: Destroy
-      create: Create
-      back: Back
-      show: Show
-      edit: Edit
-    index:
-      title: Book list
-    new:
-      title: Registration
-    edit:
-      title: Edit
+  link:
+    show: Show
+    edit: Edit
+    destroy: Destroy
+    create: Create
+    back: Back
+    show: Show
+    edit: Edit
+  title:
+    index: Book list
+    new: Registration
+    edit: Edit
 
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,33 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  books:
+    table:
+      title: Title
+      memo: Memo
+      author: Author
+      picture: Picture
+    link:
+      show: Show
+      edit: Edit
+      destroy: Destroy
+      create: Create
+      back: Back
+      show: Show
+      edit: Edit
+    index:
+      title: Book list
+    new:
+      title: Registration
+    edit:
+      title: Edit
+
+  activerecord:
+    attributes:
+      book:
+        title: "Book Title"
+        memo: "Memo"
+        author: "Author"
+        picture: "Picture"
+  helpers:
+    submit:
+      create: "submit"
+      update: "Update"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,11 +23,11 @@ en:
   activerecord:
     attributes:
       book:
-        title: "Book Title"
-        memo: "Memo"
-        author: "Author"
-        picture: "Picture"
+        title: Book Title
+        memo: Memo
+        author: Author
+        picture: Picture
   helpers:
     submit:
-      create: "submit"
-      update: "Update"
+      create: submit
+      update: Update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,14 +8,14 @@ en:
     show: Show
     edit: Edit
   title:
-    index: Book list
+    index: List
     new: Registration
     edit: Edit
 
   activerecord:
     attributes:
       book:
-        title: Book Title
+        title: Title
         memo: Memo
         author: Author
         picture: Picture

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,11 +23,11 @@ ja:
   activerecord:
     attributes:
       book:
-        title: "本のタイトル"
-        memo: "メモ"
-        author: "著者"
-        picture: "写真"
+        title: 本のタイトル
+        memo: メモ
+        author: 著者
+        picture: 写真
   helpers:
     submit:
-      create: "登録する"
-      update: "更新する"
+      create: 登録する
+      update: 更新する

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,10 +1,4 @@
 ja:
-  books:
-    table:
-      title: タイトル
-      memo: メモ
-      author: 著者
-      picture: 写真
   link:
     show: 詳細
     edit: 編集

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,20 +5,18 @@ ja:
       memo: メモ
       author: 著者
       picture: 写真
-    link:
-      show: 詳細
-      edit: 編集
-      destroy: 削除
-      create: 新規作成
-      back: 本一覧に戻る
-      show: 詳細へ
-      edit: 編集へ
-    index:
-      title: 本一覧
-    new:
-      title: 登録
-    edit:
-      title: 編集
+  link:
+    show: 詳細
+    edit: 編集
+    destroy: 削除
+    create: 新規作成
+    back: 本一覧に戻る
+    show: 詳細へ
+    edit: 編集へ
+  title:
+    index: 本一覧
+    new: 登録
+    edit: 編集
 
   activerecord:
     attributes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,33 @@
+ja:
+  books:
+    table:
+      title: タイトル
+      memo: メモ
+      author: 著者
+      picture: 写真
+    link:
+      show: 詳細
+      edit: 編集
+      destroy: 削除
+      create: 新規作成
+      back: 本一覧に戻る
+      show: 詳細へ
+      edit: 編集へ
+    index:
+      title: 本一覧
+    new:
+      title: 登録
+    edit:
+      title: 編集
+
+  activerecord:
+    attributes:
+      book:
+        title: "本のタイトル"
+        memo: "メモ"
+        author: "著者"
+        picture: "写真"
+  helpers:
+    submit:
+      create: "登録する"
+      update: "更新する"


### PR DESCRIPTION
# PRの概要
概要issue: https://github.com/Judeeeee/fjord-books_app/issues/3
該当プラクティス: [Rails の i18n を理解する](https://bootcamp.fjord.jp/practices/39)

### 確認項目(課題の提出に必須な事項)
- i18nのセットアップ
   - [x] デフォルトの言語設定をconfig/application.rbに記述する
     - 該当hash : 7cca242
- 日英それぞれの辞書ファイルの作成
  - [x] 日本語の翻訳辞書をconfig/locales配下のYAMLファイルに`ja.yml`として作成する
    - 該当hash:  844be7f
    - `ja.yml`に日本語翻訳ファイルを記述する
      - [x] 入力フォームラベル
        - activerecordのattributesの下に記述する
      - [x] submitボタンの言語表記 
        - helperメソッドの下に記述する
      - [x] 遷移リンク、ページタイトル、ラベル情報(ex: 本のタイトル、著者などのラベル)
        - Actionに留意して、yml記述で日本語辞書を作成する
     - [x] ブラウザでの表示を見る
       - [x] `/books`
         - 該当hash: 5b91ae3
       - [x] `/books/:id`
         - 該当hash: dc63623
       - [x] `/books/new`
         - 該当hash: f0925ab
       - [x] `books/:id/edit`
         - 該当hash: 04c6b66
  - [x] 英語版の翻訳をconfig/locales配下のYAMLファイルに`en.yml`として作成する
    - 該当hash: 798fc7d
  - [x] 上記の日本語翻訳ファイルの手順に沿って、英語版もブラウザで表示できるようにする
- ブラウザでの日英表示の切り替え
  - [x] config/application.rbに記述された、デフォルトの言語設定を日本語<=>英語に設定する
  - [x] rails serverを再起動させて、ブラウザの言語が日本語<=>英語に切り替わることを確認する
    - [x] 英語と日本語で切り替わってることろが確認できるスクリーンショットをとる
      - 撮影時のhash: 35006e7
        - 日本語版
          - <img width="1079" alt="スクリーンショット 2022-05-09 19 47 31" src="https://user-images.githubusercontent.com/43412616/167787115-890716da-a838-4e8a-9387-e3b01d6a056d.png">
        - 英語版
          - <img width="1072" alt="スクリーンショット 2022-05-09 19 49 03" src="https://user-images.githubusercontent.com/43412616/167787181-615ec587-c183-4096-8701-7fe3a1a0e63f.png">
- rubocop
  - [x] rubocopをpassしたターミナルのスクリーンショット
    - 該当hash: 35006e7
      - <img width="996" alt="スクリーンショット 2022-05-09 19 45 58" src="https://user-images.githubusercontent.com/43412616/167787491-10819c20-7078-4868-9370-5c66ff71a1b7.png">
